### PR TITLE
Refactor view controllers

### DIFF
--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		0320B59B2147916D00A8D646 /* MainTabBarViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320B59A2147916D00A8D646 /* MainTabBarViewControllerTests.swift */; };
 		0320B59D2147981D00A8D646 /* TransactionsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320B59C2147981D00A8D646 /* TransactionsViewControllerTests.swift */; };
 		0320B59F21479C3B00A8D646 /* TouchIDConfirmationViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320B59E21479C3B00A8D646 /* TouchIDConfirmationViewControllerTests.swift */; };
+		0320B5A22147D2C200A8D646 /* LoginViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320B5A12147D2C200A8D646 /* LoginViewModelProtocol.swift */; };
+		0320B5A42147D2FD00A8D646 /* TestLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320B5A32147D2FD00A8D646 /* TestLoginViewModel.swift */; };
 		0320EB67213F8C15001E711F /* ProfileTableViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320EB66213F8C15001E711F /* ProfileTableViewModelTests.swift */; };
 		0320EB69213F9167001E711F /* MainTabBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0320EB68213F9167001E711F /* MainTabBarViewModelTests.swift */; };
 		0326EF652138F0030062DBE3 /* Fixtures in Resources */ = {isa = PBXBuildFile; fileRef = 0326EF642138F0030062DBE3 /* Fixtures */; };
@@ -125,6 +127,8 @@
 		0320B59A2147916D00A8D646 /* MainTabBarViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewControllerTests.swift; sourceTree = "<group>"; };
 		0320B59C2147981D00A8D646 /* TransactionsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsViewControllerTests.swift; sourceTree = "<group>"; };
 		0320B59E21479C3B00A8D646 /* TouchIDConfirmationViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchIDConfirmationViewControllerTests.swift; sourceTree = "<group>"; };
+		0320B5A12147D2C200A8D646 /* LoginViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModelProtocol.swift; sourceTree = "<group>"; };
+		0320B5A32147D2FD00A8D646 /* TestLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLoginViewModel.swift; sourceTree = "<group>"; };
 		0320EB66213F8C15001E711F /* ProfileTableViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTableViewModelTests.swift; sourceTree = "<group>"; };
 		0320EB68213F9167001E711F /* MainTabBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewModelTests.swift; sourceTree = "<group>"; };
 		0326EF642138F0030062DBE3 /* Fixtures */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Fixtures; sourceTree = "<group>"; };
@@ -248,12 +252,21 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0320B5A02147D2B700A8D646 /* ViewModelProtocols */ = {
+			isa = PBXGroup;
+			children = (
+				0320B5A12147D2C200A8D646 /* LoginViewModelProtocol.swift */,
+			);
+			path = ViewModelProtocols;
+			sourceTree = "<group>";
+		};
 		0326EF622138EFF90062DBE3 /* TestMocks */ = {
 			isa = PBXGroup;
 			children = (
 				0326EF682138F0E80062DBE3 /* TestSessionManager.swift */,
 				0326EF6A2138F6CB0062DBE3 /* StubGenerator.swift */,
 				03E3CEE8213F982A00A199C5 /* TestTransactionLoader.swift */,
+				0320B5A32147D2FD00A8D646 /* TestLoginViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -314,6 +327,7 @@
 				033A63C52123E2CB00A2D08B /* Storyboards */,
 				03C2A65121269A6700267E7F /* ViewControllers */,
 				03C2A65221269A6800267E7F /* ViewModels */,
+				0320B5A02147D2B700A8D646 /* ViewModelProtocols */,
 				03C2A690212A31C600267E7F /* Views */,
 				033A63A52123E02800A2D08B /* AppDelegate.swift */,
 				033A63B12123E02C00A2D08B /* Info.plist */,
@@ -773,6 +787,7 @@
 				03C2A65F21269C2300267E7F /* CustomView.swift in Sources */,
 				03FB799B212FEE2500890D72 /* Paginator.swift in Sources */,
 				032F7A76212A478200AAC753 /* AppState.swift in Sources */,
+				0320B5A22147D2C200A8D646 /* LoginViewModelProtocol.swift in Sources */,
 				0380AAE7212D13C3006B2193 /* QRGenerator.swift in Sources */,
 				032F7A74212A476400AAC753 /* Closure.swift in Sources */,
 				0380AAEF212D54EF006B2193 /* SignupViewController.swift in Sources */,
@@ -817,6 +832,7 @@
 				033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */,
 				0320EB67213F8C15001E711F /* ProfileTableViewModelTests.swift in Sources */,
 				0326EF6B2138F6CB0062DBE3 /* StubGenerator.swift in Sources */,
+				0320B5A42147D2FD00A8D646 /* TestLoginViewModel.swift in Sources */,
 				0320EB69213F9167001E711F /* MainTabBarViewModelTests.swift in Sources */,
 				0372E3B9213E41970058D0A6 /* BalanceDetailViewModelTests.swift in Sources */,
 				0326EF672138F0BC0062DBE3 /* LoadingViewModelTests.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		032FAF362148C8F900992742 /* TestLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF352148C8F900992742 /* TestLoadingViewModel.swift */; };
 		032FAF382148CC4100992742 /* BalanceListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */; };
 		032FAF3A2148CE6000992742 /* TestBalanceListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */; };
+		032FAF3C2149010100992742 /* BalanceDetailViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */; };
+		032FAF3E214902B600992742 /* TestBalanceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -150,6 +152,8 @@
 		032FAF352148C8F900992742 /* TestLoadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLoadingViewModel.swift; sourceTree = "<group>"; };
 		032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceListViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceListViewModel.swift; sourceTree = "<group>"; };
+		032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceDetailViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceDetailViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -266,6 +270,7 @@
 				0320B5A12147D2C200A8D646 /* LoginViewModelProtocol.swift */,
 				032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */,
 				032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */,
+				032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -279,6 +284,7 @@
 				0320B5A32147D2FD00A8D646 /* TestLoginViewModel.swift */,
 				032FAF352148C8F900992742 /* TestLoadingViewModel.swift */,
 				032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */,
+				032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -787,6 +793,7 @@
 				0380AAD7212BF4F8006B2193 /* Observable.swift in Sources */,
 				032F7A72212A474C00AAC753 /* Storyboard.swift in Sources */,
 				03A0C00C2135173B00E31833 /* UserDefaultsWrapper.swift in Sources */,
+				032FAF3C2149010100992742 /* BalanceDetailViewModelProtocol.swift in Sources */,
 				03FB7982212E9AB800890D72 /* ProfileTableViewModel.swift in Sources */,
 				03885C172133B69300E78F69 /* TouchIDConfirmationViewModel.swift in Sources */,
 				03FB7991212FECA200890D72 /* TransactionsViewModel.swift in Sources */,
@@ -853,6 +860,7 @@
 				0372E3B9213E41970058D0A6 /* BalanceDetailViewModelTests.swift in Sources */,
 				0326EF672138F0BC0062DBE3 /* LoadingViewModelTests.swift in Sources */,
 				03E3CEE7213F979500A199C5 /* TransactionsViewModelTests.swift in Sources */,
+				032FAF3E214902B600992742 /* TestBalanceDetailViewModel.swift in Sources */,
 				03B9A0DB2146289D006B056A /* BalanceListViewControllerTests.swift in Sources */,
 				03E5F192214103A80089939D /* BaseViewControllerTests.swift in Sources */,
 				03E3CEE9213F982A00A199C5 /* TestTransactionLoader.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		032FAF4221490C9100992742 /* TestBalanceNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */; };
 		032FAF4421490FC400992742 /* QRViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4321490FC400992742 /* QRViewModelProtocol.swift */; };
 		032FAF462149104B00992742 /* TestQRViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF452149104B00992742 /* TestQRViewModel.swift */; };
+		032FAF48214911A000992742 /* SignupViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF47214911A000992742 /* SignupViewModelProtocol.swift */; };
+		032FAF4A2149127300992742 /* TestSignupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF492149127300992742 /* TestSignupViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -162,6 +164,8 @@
 		032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceNavigationViewModel.swift; sourceTree = "<group>"; };
 		032FAF4321490FC400992742 /* QRViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF452149104B00992742 /* TestQRViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestQRViewModel.swift; sourceTree = "<group>"; };
+		032FAF47214911A000992742 /* SignupViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF492149127300992742 /* TestSignupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSignupViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -281,6 +285,7 @@
 				032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */,
 				032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */,
 				032FAF4321490FC400992742 /* QRViewModelProtocol.swift */,
+				032FAF47214911A000992742 /* SignupViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -297,6 +302,7 @@
 				032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */,
 				032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */,
 				032FAF452149104B00992742 /* TestQRViewModel.swift */,
+				032FAF492149127300992742 /* TestSignupViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -825,6 +831,7 @@
 				0380AAE7212D13C3006B2193 /* QRGenerator.swift in Sources */,
 				032F7A74212A476400AAC753 /* Closure.swift in Sources */,
 				0380AAEF212D54EF006B2193 /* SignupViewController.swift in Sources */,
+				032FAF48214911A000992742 /* SignupViewModelProtocol.swift in Sources */,
 				032F7A6E212A371000AAC753 /* BalanceCellViewModel.swift in Sources */,
 				0380AAD9212C12AF006B2193 /* BalanceNavigationViewController.swift in Sources */,
 				032F7A7A212A5A7200AAC753 /* BalanceDetailViewModel.swift in Sources */,
@@ -851,6 +858,7 @@
 				0371EA61213D241700BBF92C /* LoginViewModelTests.swift in Sources */,
 				0372E3B7213E31590058D0A6 /* BalanceListViewModelTests.swift in Sources */,
 				03E5F18C2140E99A0089939D /* TouchIDConfirmationViewModelTests.swift in Sources */,
+				032FAF4A2149127300992742 /* TestSignupViewModel.swift in Sources */,
 				03B9A0DD21463B31006B056A /* BalanceDetailViewControllerTests.swift in Sources */,
 				03B9A0DF21464B39006B056A /* BalanceNavigationViewControllerTests.swift in Sources */,
 				03B9A0D7214129D9006B056A /* LoginViewControllerTests.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		032FAF4A2149127300992742 /* TestSignupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF492149127300992742 /* TestSignupViewModel.swift */; };
 		032FAF4C214915F200992742 /* ProfileTableViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4B214915F200992742 /* ProfileTableViewModelProtocol.swift */; };
 		032FAF4E214916F100992742 /* TestProfileTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */; };
+		032FAF50214919B500992742 /* TransactionsViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4F214919B500992742 /* TransactionsViewModelProtocol.swift */; };
+		032FAF5221491A8000992742 /* TestTransactionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF5121491A8000992742 /* TestTransactionsViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -170,6 +172,8 @@
 		032FAF492149127300992742 /* TestSignupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSignupViewModel.swift; sourceTree = "<group>"; };
 		032FAF4B214915F200992742 /* ProfileTableViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTableViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProfileTableViewModel.swift; sourceTree = "<group>"; };
+		032FAF4F214919B500992742 /* TransactionsViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF5121491A8000992742 /* TestTransactionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTransactionsViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -291,6 +295,7 @@
 				032FAF4321490FC400992742 /* QRViewModelProtocol.swift */,
 				032FAF47214911A000992742 /* SignupViewModelProtocol.swift */,
 				032FAF4B214915F200992742 /* ProfileTableViewModelProtocol.swift */,
+				032FAF4F214919B500992742 /* TransactionsViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -309,6 +314,7 @@
 				032FAF452149104B00992742 /* TestQRViewModel.swift */,
 				032FAF492149127300992742 /* TestSignupViewModel.swift */,
 				032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */,
+				032FAF5121491A8000992742 /* TestTransactionsViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -852,6 +858,7 @@
 				03C2A66C2126A25100267E7F /* SessionManager.swift in Sources */,
 				03FB7980212E9AA300890D72 /* ProfileTableViewController.swift in Sources */,
 				03E5F19421410B100089939D /* BaseViewControllerProtocols.swift in Sources */,
+				032FAF50214919B500992742 /* TransactionsViewModelProtocol.swift in Sources */,
 				0381C20B2137DEE200F813E3 /* MBProgressHUDBuilder.swift in Sources */,
 				032FAF4021490C3E00992742 /* BalanceNavigationViewModelProtocol.swift in Sources */,
 			);
@@ -896,6 +903,7 @@
 				03B9A0DB2146289D006B056A /* BalanceListViewControllerTests.swift in Sources */,
 				03E5F192214103A80089939D /* BaseViewControllerTests.swift in Sources */,
 				03E3CEE9213F982A00A199C5 /* TestTransactionLoader.swift in Sources */,
+				032FAF5221491A8000992742 /* TestTransactionsViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		032FAF3A2148CE6000992742 /* TestBalanceListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */; };
 		032FAF3C2149010100992742 /* BalanceDetailViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */; };
 		032FAF3E214902B600992742 /* TestBalanceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */; };
+		032FAF4021490C3E00992742 /* BalanceNavigationViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */; };
+		032FAF4221490C9100992742 /* TestBalanceNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -154,6 +156,8 @@
 		032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceListViewModel.swift; sourceTree = "<group>"; };
 		032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceDetailViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceDetailViewModel.swift; sourceTree = "<group>"; };
+		032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceNavigationViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceNavigationViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -271,6 +275,7 @@
 				032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */,
 				032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */,
 				032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */,
+				032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -285,6 +290,7 @@
 				032FAF352148C8F900992742 /* TestLoadingViewModel.swift */,
 				032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */,
 				032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */,
+				032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -826,6 +832,7 @@
 				03FB7980212E9AA300890D72 /* ProfileTableViewController.swift in Sources */,
 				03E5F19421410B100089939D /* BaseViewControllerProtocols.swift in Sources */,
 				0381C20B2137DEE200F813E3 /* MBProgressHUDBuilder.swift in Sources */,
+				032FAF4021490C3E00992742 /* BalanceNavigationViewModelProtocol.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -850,6 +857,7 @@
 				032FAF362148C8F900992742 /* TestLoadingViewModel.swift in Sources */,
 				0320B59B2147916D00A8D646 /* MainTabBarViewControllerTests.swift in Sources */,
 				0320B59F21479C3B00A8D646 /* TouchIDConfirmationViewControllerTests.swift in Sources */,
+				032FAF4221490C9100992742 /* TestBalanceNavigationViewModel.swift in Sources */,
 				03F2C378213E68E600BCC867 /* BalanceNavigationViewModelTests.swift in Sources */,
 				033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */,
 				0320EB67213F8C15001E711F /* ProfileTableViewModelTests.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		032F7A7A212A5A7200AAC753 /* BalanceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032F7A79212A5A7200AAC753 /* BalanceDetailViewModel.swift */; };
 		032FAF342148C7F000992742 /* LoadingViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */; };
 		032FAF362148C8F900992742 /* TestLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF352148C8F900992742 /* TestLoadingViewModel.swift */; };
+		032FAF382148CC4100992742 /* BalanceListViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */; };
+		032FAF3A2148CE6000992742 /* TestBalanceListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -146,6 +148,8 @@
 		032F7A79212A5A7200AAC753 /* BalanceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceDetailViewModel.swift; sourceTree = "<group>"; };
 		032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF352148C8F900992742 /* TestLoadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLoadingViewModel.swift; sourceTree = "<group>"; };
+		032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceListViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceListViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -261,6 +265,7 @@
 			children = (
 				0320B5A12147D2C200A8D646 /* LoginViewModelProtocol.swift */,
 				032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */,
+				032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -273,6 +278,7 @@
 				03E3CEE8213F982A00A199C5 /* TestTransactionLoader.swift */,
 				0320B5A32147D2FD00A8D646 /* TestLoginViewModel.swift */,
 				032FAF352148C8F900992742 /* TestLoadingViewModel.swift */,
+				032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -786,6 +792,7 @@
 				03FB7991212FECA200890D72 /* TransactionsViewModel.swift in Sources */,
 				03C2A65921269AA500267E7F /* BaseViewController.swift in Sources */,
 				0380AAE5212D11E5006B2193 /* QRViewModel.swift in Sources */,
+				032FAF382148CC4100992742 /* BalanceListViewModelProtocol.swift in Sources */,
 				03885C152133B68500E78F69 /* TouchIDConfirmationViewController.swift in Sources */,
 				03C2A66021269C2300267E7F /* Extension.swift in Sources */,
 				03A0C00A21350FFD00E31833 /* KeychainWrapper.swift in Sources */,
@@ -840,6 +847,7 @@
 				033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */,
 				0320EB67213F8C15001E711F /* ProfileTableViewModelTests.swift in Sources */,
 				0326EF6B2138F6CB0062DBE3 /* StubGenerator.swift in Sources */,
+				032FAF3A2148CE6000992742 /* TestBalanceListViewModel.swift in Sources */,
 				0320B5A42147D2FD00A8D646 /* TestLoginViewModel.swift in Sources */,
 				0320EB69213F9167001E711F /* MainTabBarViewModelTests.swift in Sources */,
 				0372E3B9213E41970058D0A6 /* BalanceDetailViewModelTests.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -28,6 +28,8 @@
 		032F7A76212A478200AAC753 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032F7A75212A478200AAC753 /* AppState.swift */; };
 		032F7A78212A5A6300AAC753 /* BalanceDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032F7A77212A5A6300AAC753 /* BalanceDetailViewController.swift */; };
 		032F7A7A212A5A7200AAC753 /* BalanceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032F7A79212A5A7200AAC753 /* BalanceDetailViewModel.swift */; };
+		032FAF342148C7F000992742 /* LoadingViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */; };
+		032FAF362148C8F900992742 /* TestLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF352148C8F900992742 /* TestLoadingViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -142,6 +144,8 @@
 		032F7A75212A478200AAC753 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		032F7A77212A5A6300AAC753 /* BalanceDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceDetailViewController.swift; sourceTree = "<group>"; };
 		032F7A79212A5A7200AAC753 /* BalanceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceDetailViewModel.swift; sourceTree = "<group>"; };
+		032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF352148C8F900992742 /* TestLoadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLoadingViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -256,6 +260,7 @@
 			isa = PBXGroup;
 			children = (
 				0320B5A12147D2C200A8D646 /* LoginViewModelProtocol.swift */,
+				032FAF332148C7F000992742 /* LoadingViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -267,6 +272,7 @@
 				0326EF6A2138F6CB0062DBE3 /* StubGenerator.swift */,
 				03E3CEE8213F982A00A199C5 /* TestTransactionLoader.swift */,
 				0320B5A32147D2FD00A8D646 /* TestLoginViewModel.swift */,
+				032FAF352148C8F900992742 /* TestLoadingViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -764,6 +770,7 @@
 				033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */,
 				03C2A67B2126BFBD00267E7F /* LoadingViewModel.swift in Sources */,
 				03C2A66121269C2300267E7F /* Theme.swift in Sources */,
+				032FAF342148C7F000992742 /* LoadingViewModelProtocol.swift in Sources */,
 				0381C2092137D21100F813E3 /* LoadingView.swift in Sources */,
 				032F7A70212A441E00AAC753 /* OmiseGOWrapper.swift in Sources */,
 				03C2A66321269CDF00267E7F /* Constant.swift in Sources */,
@@ -826,6 +833,7 @@
 				03B9A0D921413832006B056A /* LoadingViewControllerTests.swift in Sources */,
 				0320B599214783F600A8D646 /* ProfileTableViewControllerTests.swift in Sources */,
 				0326EF692138F0E80062DBE3 /* TestSessionManager.swift in Sources */,
+				032FAF362148C8F900992742 /* TestLoadingViewModel.swift in Sources */,
 				0320B59B2147916D00A8D646 /* MainTabBarViewControllerTests.swift in Sources */,
 				0320B59F21479C3B00A8D646 /* TouchIDConfirmationViewControllerTests.swift in Sources */,
 				03F2C378213E68E600BCC867 /* BalanceNavigationViewModelTests.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		032FAF4E214916F100992742 /* TestProfileTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */; };
 		032FAF50214919B500992742 /* TransactionsViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4F214919B500992742 /* TransactionsViewModelProtocol.swift */; };
 		032FAF5221491A8000992742 /* TestTransactionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF5121491A8000992742 /* TestTransactionsViewModel.swift */; };
+		032FAF5421491ED500992742 /* TouchIDConfirmationViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF5321491ED500992742 /* TouchIDConfirmationViewModelProtocol.swift */; };
+		032FAF5621491F6A00992742 /* TestTouchIDConfirmationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF5521491F6A00992742 /* TestTouchIDConfirmationViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -174,6 +176,8 @@
 		032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProfileTableViewModel.swift; sourceTree = "<group>"; };
 		032FAF4F214919B500992742 /* TransactionsViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionsViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF5121491A8000992742 /* TestTransactionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTransactionsViewModel.swift; sourceTree = "<group>"; };
+		032FAF5321491ED500992742 /* TouchIDConfirmationViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchIDConfirmationViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF5521491F6A00992742 /* TestTouchIDConfirmationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTouchIDConfirmationViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -296,6 +300,7 @@
 				032FAF47214911A000992742 /* SignupViewModelProtocol.swift */,
 				032FAF4B214915F200992742 /* ProfileTableViewModelProtocol.swift */,
 				032FAF4F214919B500992742 /* TransactionsViewModelProtocol.swift */,
+				032FAF5321491ED500992742 /* TouchIDConfirmationViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -315,6 +320,7 @@
 				032FAF492149127300992742 /* TestSignupViewModel.swift */,
 				032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */,
 				032FAF5121491A8000992742 /* TestTransactionsViewModel.swift */,
+				032FAF5521491F6A00992742 /* TestTouchIDConfirmationViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -838,6 +844,7 @@
 				03C2A65521269A9D00267E7F /* BaseViewModel.swift in Sources */,
 				03C2A68D212A317D00267E7F /* BalanceListViewController.swift in Sources */,
 				03C2A65F21269C2300267E7F /* CustomView.swift in Sources */,
+				032FAF5421491ED500992742 /* TouchIDConfirmationViewModelProtocol.swift in Sources */,
 				03FB799B212FEE2500890D72 /* Paginator.swift in Sources */,
 				032F7A76212A478200AAC753 /* AppState.swift in Sources */,
 				0320B5A22147D2C200A8D646 /* LoginViewModelProtocol.swift in Sources */,
@@ -876,6 +883,7 @@
 				03B9A0DD21463B31006B056A /* BalanceDetailViewControllerTests.swift in Sources */,
 				03B9A0DF21464B39006B056A /* BalanceNavigationViewControllerTests.swift in Sources */,
 				03B9A0D7214129D9006B056A /* LoginViewControllerTests.swift in Sources */,
+				032FAF5621491F6A00992742 /* TestTouchIDConfirmationViewModel.swift in Sources */,
 				0320B59D2147981D00A8D646 /* TransactionsViewControllerTests.swift in Sources */,
 				03B9A0E121465A47006B056A /* QRViewControllerTests.swift in Sources */,
 				0320B5972147772000A8D646 /* SignupConfirmationViewControllerTests.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		032FAF3E214902B600992742 /* TestBalanceDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */; };
 		032FAF4021490C3E00992742 /* BalanceNavigationViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */; };
 		032FAF4221490C9100992742 /* TestBalanceNavigationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */; };
+		032FAF4421490FC400992742 /* QRViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4321490FC400992742 /* QRViewModelProtocol.swift */; };
+		032FAF462149104B00992742 /* TestQRViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF452149104B00992742 /* TestQRViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -158,6 +160,8 @@
 		032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceDetailViewModel.swift; sourceTree = "<group>"; };
 		032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BalanceNavigationViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestBalanceNavigationViewModel.swift; sourceTree = "<group>"; };
+		032FAF4321490FC400992742 /* QRViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF452149104B00992742 /* TestQRViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestQRViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -276,6 +280,7 @@
 				032FAF372148CC4100992742 /* BalanceListViewModelProtocol.swift */,
 				032FAF3B2149010100992742 /* BalanceDetailViewModelProtocol.swift */,
 				032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */,
+				032FAF4321490FC400992742 /* QRViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -291,6 +296,7 @@
 				032FAF392148CE6000992742 /* TestBalanceListViewModel.swift */,
 				032FAF3D214902B600992742 /* TestBalanceDetailViewModel.swift */,
 				032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */,
+				032FAF452149104B00992742 /* TestQRViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -785,6 +791,7 @@
 				03C2A68F212A318C00267E7F /* BalanceListViewModel.swift in Sources */,
 				03FB797A212E6EAD00890D72 /* SignupConfirmationViewController.swift in Sources */,
 				03885C132133ADDB00E78F69 /* Biometric.swift in Sources */,
+				032FAF4421490FC400992742 /* QRViewModelProtocol.swift in Sources */,
 				033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */,
 				03C2A67B2126BFBD00267E7F /* LoadingViewModel.swift in Sources */,
 				03C2A66121269C2300267E7F /* Theme.swift in Sources */,
@@ -851,6 +858,7 @@
 				03B9A0E121465A47006B056A /* QRViewControllerTests.swift in Sources */,
 				0320B5972147772000A8D646 /* SignupConfirmationViewControllerTests.swift in Sources */,
 				03F2C37A213E7CB000BCC867 /* SignupViewModelTests.swift in Sources */,
+				032FAF462149104B00992742 /* TestQRViewModel.swift in Sources */,
 				03B9A0D921413832006B056A /* LoadingViewControllerTests.swift in Sources */,
 				0320B599214783F600A8D646 /* ProfileTableViewControllerTests.swift in Sources */,
 				0326EF692138F0E80062DBE3 /* TestSessionManager.swift in Sources */,

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		032FAF462149104B00992742 /* TestQRViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF452149104B00992742 /* TestQRViewModel.swift */; };
 		032FAF48214911A000992742 /* SignupViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF47214911A000992742 /* SignupViewModelProtocol.swift */; };
 		032FAF4A2149127300992742 /* TestSignupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF492149127300992742 /* TestSignupViewModel.swift */; };
+		032FAF4C214915F200992742 /* ProfileTableViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4B214915F200992742 /* ProfileTableViewModelProtocol.swift */; };
+		032FAF4E214916F100992742 /* TestProfileTableViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */; };
 		033A63A62123E02800A2D08B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033A63A52123E02800A2D08B /* AppDelegate.swift */; };
 		033A63CB2123E2CB00A2D08B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 033A63C92123E2CB00A2D08B /* Assets.xcassets */; };
 		033F28B821465FCA00E0DC02 /* SignupViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033F28B721465FCA00E0DC02 /* SignupViewControllerTests.swift */; };
@@ -166,6 +168,8 @@
 		032FAF452149104B00992742 /* TestQRViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestQRViewModel.swift; sourceTree = "<group>"; };
 		032FAF47214911A000992742 /* SignupViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupViewModelProtocol.swift; sourceTree = "<group>"; };
 		032FAF492149127300992742 /* TestSignupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSignupViewModel.swift; sourceTree = "<group>"; };
+		032FAF4B214915F200992742 /* ProfileTableViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileTableViewModelProtocol.swift; sourceTree = "<group>"; };
+		032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProfileTableViewModel.swift; sourceTree = "<group>"; };
 		033A63A22123E02800A2D08B /* POSClient.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = POSClient.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		033A63A52123E02800A2D08B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		033A63B12123E02C00A2D08B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -286,6 +290,7 @@
 				032FAF3F21490C3E00992742 /* BalanceNavigationViewModelProtocol.swift */,
 				032FAF4321490FC400992742 /* QRViewModelProtocol.swift */,
 				032FAF47214911A000992742 /* SignupViewModelProtocol.swift */,
+				032FAF4B214915F200992742 /* ProfileTableViewModelProtocol.swift */,
 			);
 			path = ViewModelProtocols;
 			sourceTree = "<group>";
@@ -303,6 +308,7 @@
 				032FAF4121490C9100992742 /* TestBalanceNavigationViewModel.swift */,
 				032FAF452149104B00992742 /* TestQRViewModel.swift */,
 				032FAF492149127300992742 /* TestSignupViewModel.swift */,
+				032FAF4D214916F100992742 /* TestProfileTableViewModel.swift */,
 			);
 			path = TestMocks;
 			sourceTree = "<group>";
@@ -819,6 +825,7 @@
 				03C2A65921269AA500267E7F /* BaseViewController.swift in Sources */,
 				0380AAE5212D11E5006B2193 /* QRViewModel.swift in Sources */,
 				032FAF382148CC4100992742 /* BalanceListViewModelProtocol.swift in Sources */,
+				032FAF4C214915F200992742 /* ProfileTableViewModelProtocol.swift in Sources */,
 				03885C152133B68500E78F69 /* TouchIDConfirmationViewController.swift in Sources */,
 				03C2A66021269C2300267E7F /* Extension.swift in Sources */,
 				03A0C00A21350FFD00E31833 /* KeychainWrapper.swift in Sources */,
@@ -884,6 +891,7 @@
 				0372E3B9213E41970058D0A6 /* BalanceDetailViewModelTests.swift in Sources */,
 				0326EF672138F0BC0062DBE3 /* LoadingViewModelTests.swift in Sources */,
 				03E3CEE7213F979500A199C5 /* TransactionsViewModelTests.swift in Sources */,
+				032FAF4E214916F100992742 /* TestProfileTableViewModel.swift in Sources */,
 				032FAF3E214902B600992742 /* TestBalanceDetailViewModel.swift in Sources */,
 				03B9A0DB2146289D006B056A /* BalanceListViewControllerTests.swift in Sources */,
 				03E5F192214103A80089939D /* BaseViewControllerTests.swift in Sources */,

--- a/POSClient/Helpers/Storyboard.swift
+++ b/POSClient/Helpers/Storyboard.swift
@@ -34,4 +34,8 @@ enum Storyboard {
     var storyboard: UIStoryboard {
         return UIStoryboard(name: self.name, bundle: nil)
     }
+
+    func viewControllerFromId<T: UIViewController>() -> T? {
+        return self.storyboard.instantiateViewController(withIdentifier: String(describing: T.self)) as? T
+    }
 }

--- a/POSClient/ViewControllers/BalanceDetailViewController.swift
+++ b/POSClient/ViewControllers/BalanceDetailViewController.swift
@@ -15,7 +15,13 @@ class BalanceDetailViewController: BaseViewController {
     @IBOutlet var lastUpdatedLabel: UILabel!
     @IBOutlet var lastUpdatedValueLabel: UILabel!
 
-    let viewModel: BalanceDetailViewModel = BalanceDetailViewModel()
+    private var viewModel: BalanceDetailViewModelProtocol = BalanceDetailViewModel()
+
+    class func initWithViewModel(_ viewModel: BalanceDetailViewModelProtocol = BalanceDetailViewModel()) -> BalanceDetailViewController? {
+        guard let balanceDetailVC: BalanceDetailViewController = Storyboard.balance.viewControllerFromId() else { return nil }
+        balanceDetailVC.viewModel = viewModel
+        return balanceDetailVC
+    }
 
     func setup(withBalance balance: Balance) {
         self.viewModel.balance = balance

--- a/POSClient/ViewControllers/BalanceListViewController.swift
+++ b/POSClient/ViewControllers/BalanceListViewController.swift
@@ -12,17 +12,23 @@ class BalanceListViewController: BaseViewController {
     let balanceDetailSegueIdentifier = "showBalanceDetailViewController"
     let profileSegueIdentifier = "showProfileViewController"
 
-    let viewModel: BalanceListViewModel = BalanceListViewModel()
+    private var viewModel: BalanceListViewModelProtocol = BalanceListViewModel()
     var refreshControl: UIRefreshControl!
 
     @IBOutlet var tableView: UITableView!
+
+    class func initWithViewModel(_ viewModel: BalanceListViewModelProtocol = BalanceListViewModel()) -> BalanceListViewController? {
+        guard let balanceListVC: BalanceListViewController = Storyboard.balance.viewControllerFromId() else { return nil }
+        balanceListVC.viewModel = viewModel
+        return balanceListVC
+    }
 
     override func configureView() {
         super.configureView()
         self.navigationItem.title = self.viewModel.viewTitle
         self.refreshControl = UIRefreshControl()
         self.refreshControl.tintColor = Color.black.uiColor()
-        self.refreshControl.addTarget(self.viewModel, action: #selector(self.viewModel.loadData), for: .valueChanged)
+        self.refreshControl.addTarget(self, action: #selector(self.loadDataBridge), for: .valueChanged)
         self.tableView.registerNib(tableViewCell: BalanceTableViewCell.self)
         self.tableView.tableFooterView = UIView()
         self.tableView.estimatedRowHeight = 72
@@ -51,6 +57,10 @@ class BalanceListViewController: BaseViewController {
             let balance: Balance = sender as? Balance {
             vc.setup(withBalance: balance)
         }
+    }
+
+    @objc private func loadDataBridge() {
+        self.viewModel.loadData()
     }
 }
 

--- a/POSClient/ViewControllers/BalanceNavigationViewController.swift
+++ b/POSClient/ViewControllers/BalanceNavigationViewController.swift
@@ -11,7 +11,8 @@ import UIKit
 class BalanceNavigationViewController: BaseNavigationViewController {
     private var viewModel: BalanceNavigationViewModelProtocol = BalanceNavigationViewModel()
 
-    class func initWithViewModel(_ viewModel: BalanceNavigationViewModelProtocol = BalanceNavigationViewModel()) -> BalanceNavigationViewController? {
+    class func initWithViewModel(_ viewModel: BalanceNavigationViewModelProtocol = BalanceNavigationViewModel()) ->
+        BalanceNavigationViewController? {
         guard let balanceNavVC: BalanceNavigationViewController = Storyboard.balance.viewControllerFromId() else { return nil }
         balanceNavVC.viewModel = viewModel
         return balanceNavVC

--- a/POSClient/ViewControllers/BalanceNavigationViewController.swift
+++ b/POSClient/ViewControllers/BalanceNavigationViewController.swift
@@ -9,7 +9,13 @@
 import UIKit
 
 class BalanceNavigationViewController: BaseNavigationViewController {
-    let viewModel: BalanceNavigationViewModel = BalanceNavigationViewModel()
+    private var viewModel: BalanceNavigationViewModelProtocol = BalanceNavigationViewModel()
+
+    class func initWithViewModel(_ viewModel: BalanceNavigationViewModelProtocol = BalanceNavigationViewModel()) -> BalanceNavigationViewController? {
+        guard let balanceNavVC: BalanceNavigationViewController = Storyboard.balance.viewControllerFromId() else { return nil }
+        balanceNavVC.viewModel = viewModel
+        return balanceNavVC
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/POSClient/ViewControllers/LoadingViewController.swift
+++ b/POSClient/ViewControllers/LoadingViewController.swift
@@ -9,10 +9,16 @@
 import UIKit
 
 class LoadingViewController: BaseViewController {
-    let viewModel: LoadingViewModel = LoadingViewModel()
-    @IBOutlet var loadingImageView: UIImageView!
+    private var viewModel: LoadingViewModelProtocol = LoadingViewModel()
 
+    @IBOutlet var loadingImageView: UIImageView!
     @IBOutlet var retryButton: UIButton!
+
+    class func initWithViewModel(_ viewModel: LoadingViewModelProtocol = LoadingViewModel()) -> LoadingViewController? {
+        guard let loadingVC: LoadingViewController = Storyboard.loading.viewControllerFromId() else { return nil }
+        loadingVC.viewModel = viewModel
+        return loadingVC
+    }
 
     override func configureView() {
         super.configureView()

--- a/POSClient/ViewControllers/LoginViewController.swift
+++ b/POSClient/ViewControllers/LoginViewController.swift
@@ -9,7 +9,7 @@
 import TPKeyboardAvoiding
 
 class LoginViewController: BaseViewController {
-    let viewModel: LoginViewModel = LoginViewModel()
+    private var viewModel: LoginViewModelProtocol = LoginViewModel()
 
     @IBOutlet var scrollView: TPKeyboardAvoidingScrollView!
     @IBOutlet var emailTextField: OMGFloatingTextField!
@@ -17,6 +17,12 @@ class LoginViewController: BaseViewController {
     @IBOutlet var loginButton: UIButton!
     @IBOutlet var bioLoginButton: UIButton!
     @IBOutlet var registerButton: UIButton!
+
+    class func initWithViewModel(_ viewModel: LoginViewModelProtocol = LoginViewModel()) -> LoginViewController? {
+        guard let loginVC: LoginViewController = Storyboard.login.viewControllerFromId() else { return nil }
+        loginVC.viewModel = viewModel
+        return loginVC
+    }
 
     override func configureView() {
         super.configureView()

--- a/POSClient/ViewControllers/ProfileTableViewController.swift
+++ b/POSClient/ViewControllers/ProfileTableViewController.swift
@@ -18,7 +18,13 @@ class ProfileTableViewController: BaseTableViewController {
     @IBOutlet var touchFaceIdSwitch: UISwitch!
     @IBOutlet var signOutLabel: UILabel!
 
-    let viewModel = ProfileTableViewModel()
+    private var viewModel: ProfileTableViewModelProtocol = ProfileTableViewModel()
+
+    class func initWithViewModel(_ viewModel: ProfileTableViewModelProtocol = ProfileTableViewModel()) -> ProfileTableViewController? {
+        guard let profileVC: ProfileTableViewController = Storyboard.profile.viewControllerFromId() else { return nil }
+        profileVC.viewModel = viewModel
+        return profileVC
+    }
 
     override func configureView() {
         super.configureView()

--- a/POSClient/ViewControllers/QRViewController.swift
+++ b/POSClient/ViewControllers/QRViewController.swift
@@ -15,7 +15,13 @@ class QRViewController: BaseViewController {
 
     var initialBrightness: CGFloat = UIScreen.main.brightness
 
-    let viewModel = QRViewModel()
+    private var viewModel: QRViewModelProtocol = QRViewModel()
+
+    class func initWithViewModel(_ viewModel: QRViewModelProtocol = QRViewModel()) -> QRViewController? {
+        guard let qrVC: QRViewController = Storyboard.qrCode.viewControllerFromId() else { return nil }
+        qrVC.viewModel = viewModel
+        return qrVC
+    }
 
     override func configureView() {
         super.configureView()

--- a/POSClient/ViewControllers/SignupViewController.swift
+++ b/POSClient/ViewControllers/SignupViewController.swift
@@ -11,7 +11,7 @@ import TPKeyboardAvoiding
 class SignupViewController: BaseViewController {
     let showSignupSuccessSegueIdentifier = "showSignupSuccessViewController"
 
-    let viewModel: SignupViewModel = SignupViewModel()
+    private var viewModel: SignupViewModelProtocol = SignupViewModel()
 
     @IBOutlet var scrollView: TPKeyboardAvoidingScrollView!
     @IBOutlet var emailTextField: OMGFloatingTextField!
@@ -20,6 +20,12 @@ class SignupViewController: BaseViewController {
     @IBOutlet var passwordHintLabel: UILabel!
     @IBOutlet var termsLabel: UILabel!
     @IBOutlet var signupButton: UIButton!
+
+    class func initWithViewModel(_ viewModel: SignupViewModelProtocol = SignupViewModel()) -> SignupViewController? {
+        guard let qrVC: SignupViewController = Storyboard.signup.viewControllerFromId() else { return nil }
+        qrVC.viewModel = viewModel
+        return qrVC
+    }
 
     override func configureView() {
         super.configureView()

--- a/POSClient/ViewControllers/SignupViewController.swift
+++ b/POSClient/ViewControllers/SignupViewController.swift
@@ -22,9 +22,9 @@ class SignupViewController: BaseViewController {
     @IBOutlet var signupButton: UIButton!
 
     class func initWithViewModel(_ viewModel: SignupViewModelProtocol = SignupViewModel()) -> SignupViewController? {
-        guard let qrVC: SignupViewController = Storyboard.signup.viewControllerFromId() else { return nil }
-        qrVC.viewModel = viewModel
-        return qrVC
+        guard let signupVC: SignupViewController = Storyboard.signup.viewControllerFromId() else { return nil }
+        signupVC.viewModel = viewModel
+        return signupVC
     }
 
     override func configureView() {

--- a/POSClient/ViewControllers/TouchIDConfirmationViewController.swift
+++ b/POSClient/ViewControllers/TouchIDConfirmationViewController.swift
@@ -9,12 +9,19 @@
 import UIKit
 
 class TouchIDConfirmationViewController: BaseViewController {
-    let viewModel: TouchIDConfirmationViewModel = TouchIDConfirmationViewModel()
+    private var viewModel: TouchIDConfirmationViewModelProtocol = TouchIDConfirmationViewModel()
 
     @IBOutlet var hintLabel: UILabel!
     @IBOutlet var emailLabel: UILabel!
     @IBOutlet var passwordTextField: OMGFloatingTextField!
     @IBOutlet var enableButton: UIButton!
+
+    class func initWithViewModel(_ viewModel: TouchIDConfirmationViewModelProtocol = TouchIDConfirmationViewModel())
+        -> TouchIDConfirmationViewController? {
+        guard let touchIDConfVC: TouchIDConfirmationViewController = Storyboard.profile.viewControllerFromId() else { return nil }
+        touchIDConfVC.viewModel = viewModel
+        return touchIDConfVC
+    }
 
     override func configureView() {
         super.configureView()

--- a/POSClient/ViewControllers/TransactionsViewController.swift
+++ b/POSClient/ViewControllers/TransactionsViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class TransactionsViewController: BaseTableViewController {
-    let viewModel: TransactionsViewModel = TransactionsViewModel()
+    private var viewModel: TransactionsViewModelProtocol = TransactionsViewModel()
 
     lazy var loadingView: UIView = {
         let loader = UIActivityIndicatorView(activityIndicatorStyle: .white)
@@ -28,6 +28,12 @@ class TransactionsViewController: BaseTableViewController {
         })
         return view
     }()
+
+    class func initWithViewModel(_ viewModel: TransactionsViewModelProtocol = TransactionsViewModel()) -> TransactionsViewController? {
+        guard let transactionsVC: TransactionsViewController = Storyboard.transaction.viewControllerFromId() else { return nil }
+        transactionsVC.viewModel = viewModel
+        return transactionsVC
+    }
 
     override func configureView() {
         super.configureView()

--- a/POSClient/ViewModelProtocols/BalanceDetailViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/BalanceDetailViewModelProtocol.swift
@@ -1,0 +1,26 @@
+//
+//  BalanceDetailViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+
+protocol BalanceDetailViewModelProtocol {
+    var onFailGetWallet: FailureClosure? { get set }
+    var onDataUpdate: SuccessClosure? { get set }
+    var onLoadStateChange: ObjectClosure<Bool>? { get set }
+
+    var balanceDisplay: String { get }
+    var tokenSymbol: String { get }
+    var title: String { get }
+    var lastUpdatedString: String { get }
+    var lastUpdated: String { get }
+    var payOrTopupAttrStr: NSAttributedString { get }
+    var balance: Balance? { get set }
+
+    func loadData()
+    func stopObserving()
+}

--- a/POSClient/ViewModelProtocols/BalanceListViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/BalanceListViewModelProtocol.swift
@@ -1,0 +1,21 @@
+//
+//  BalanceListViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+
+protocol BalanceListViewModelProtocol {
+    var onFailGetWallet: FailureClosure? { get set }
+    var onTableDataChange: SuccessClosure? { get set }
+    var onBalanceSelection: ObjectClosure<Balance>? { get set }
+    var viewTitle: String { get }
+
+    func loadData()
+    func numberOfRow() -> Int
+    func cellViewModel(forIndex index: Int) -> BalanceCellViewModel
+    func didSelectBalance(atIndex index: Int)
+}

--- a/POSClient/ViewModelProtocols/BalanceNavigationViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/BalanceNavigationViewModelProtocol.swift
@@ -1,0 +1,17 @@
+//
+//  BalanceNavigationViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol BalanceNavigationViewModelProtocol {
+    var onDisplayStyleUpdate: EmptyClosure? { get set }
+    var displayStyle: DisplayStyle { get set }
+
+    func stopObserving()
+    func updateBalances()
+}

--- a/POSClient/ViewModelProtocols/LoadingViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/LoadingViewModelProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  LoadingViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+protocol LoadingViewModelProtocol {
+    var onFailedLoading: FailureClosure? { get set }
+    var onLoadStateChange: ObjectClosure<Bool>? { get set }
+    var isLoading: Bool { get set }
+    var retryButtonTitle: String { get }
+
+    func load()
+}

--- a/POSClient/ViewModelProtocols/LoginViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/LoginViewModelProtocol.swift
@@ -1,0 +1,28 @@
+//
+//  LoginViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 11/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol LoginViewModelProtocol {
+    var updateEmailValidation: ViewModelValidationClosure? { get set }
+    var updatePasswordValidation: ViewModelValidationClosure? { get set }
+    var onFailedLogin: FailureClosure? { get set }
+    var onLoadStateChange: ObjectClosure<Bool>? { get set }
+    var emailPlaceholder: String { get }
+    var passwordPlaceholder: String { get }
+    var loginButtonTitle: String { get }
+    var registerButtonTitle: String { get }
+    var isBiometricAvailable: Bool { get }
+    var touchFaceIdButtonTitle: String { get }
+    var touchFaceIdButtonPicture: UIImage? { get }
+    var email: String? { get set }
+    var password: String? { get set }
+
+    func bioLogin()
+    func login()
+}

--- a/POSClient/ViewModelProtocols/ProfileTableViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/ProfileTableViewModelProtocol.swift
@@ -1,0 +1,30 @@
+//
+//  ProfileTableViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol ProfileTableViewModelProtocol {
+    var title: String { get }
+    var transactionLabelText: String { get }
+    var emailLabelText: String { get }
+    var signOutLabelText: String { get }
+
+    var onFailLogout: FailureClosure? { get set }
+    var onLoadStateChange: ObjectClosure<Bool>? { get set }
+    var shouldShowEnableConfirmationView: EmptyClosure? { get set }
+    var onBioStateChange: ObjectClosure<Bool>? { get set }
+
+    var switchState: Bool { get set }
+    var isBiometricAvailable: Bool { get }
+    var touchFaceIdLabelText: String { get }
+    var emailValueLabelText: String { get }
+
+    func toggleSwitch(newValue isEnabled: Bool)
+    func logout()
+    func stopObserving()
+}

--- a/POSClient/ViewModelProtocols/QRViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/QRViewModelProtocol.swift
@@ -1,0 +1,16 @@
+//
+//  QRViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol QRViewModelProtocol {
+    var title: String { get }
+    var hint: String { get }
+
+    func qrImage(withWidth width: CGFloat) -> UIImage?
+}

--- a/POSClient/ViewModelProtocols/SignupViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/SignupViewModelProtocol.swift
@@ -1,0 +1,33 @@
+//
+//  SignupViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol SignupViewModelProtocol {
+    var updateEmailValidation: ViewModelValidationClosure? { get set }
+    var updatePasswordValidation: ViewModelValidationClosure? { get set }
+    var updatePasswordConfirmationValidation: ViewModelValidationClosure? { get set }
+    var updatePasswordMatchingValidation: ViewModelValidationClosure? { get set }
+    var onSuccessfulSignup: EmptyClosure? { get set }
+    var onFailedSignup: FailureClosure? { get set }
+    var onLoadStateChange: ObjectClosure<Bool>? { get set }
+
+    var title: String { get }
+    var emailPlaceholder: String { get }
+    var passwordPlaceholder: String { get }
+    var passwordConfirmationPlaceholder: String { get }
+    var passwordHint: String { get }
+    var terms: String { get }
+    var signupButtonTitle: String { get }
+
+    var email: String? { get set }
+    var password: String? { get set }
+    var passwordConfirmation: String? { get set }
+
+    func signup()
+}

--- a/POSClient/ViewModelProtocols/TouchIDConfirmationViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/TouchIDConfirmationViewModelProtocol.swift
@@ -1,0 +1,26 @@
+//
+//  TouchIDConfirmationViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol TouchIDConfirmationViewModelProtocol {
+    var updatePasswordValidation: ViewModelValidationClosure? { get set }
+    var onSuccessEnable: EmptyClosure? { get set }
+    var onFailedEnable: FailureClosure? { get set }
+    var onLoadStateChange: ObjectClosure<Bool>? { get set }
+
+    var title: String { get }
+    var passwordPlaceholder: String { get }
+    var emailString: String { get }
+    var enableButtonTitle: String { get }
+    var hintString: String { get }
+
+    var password: String? { get set }
+
+    func enable()
+}

--- a/POSClient/ViewModelProtocols/TransactionsViewModelProtocol.swift
+++ b/POSClient/ViewModelProtocols/TransactionsViewModelProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  TransactionsViewModelProtocol.swift
+//  POSClient
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+
+protocol TransactionsViewModelProtocol {
+    var appendNewResultClosure: ObjectClosure<[IndexPath]>? { get set }
+    var reloadTableViewClosure: EmptyClosure? { get set }
+    var onFailLoadTransactions: FailureClosure? { get set }
+    var onLoadStateChange: ObjectClosure<Bool>? { get set }
+
+    var viewTitle: String { get }
+
+    func reloadTransactions()
+    func getNextTransactions()
+    func transactionCellViewModel(at indexPath: IndexPath) -> TransactionCellViewModel
+    func numberOfRow() -> Int
+    func shouldLoadNext(atIndexPath indexPath: IndexPath) -> Bool
+}

--- a/POSClient/ViewModels/BalanceDetailViewModel.swift
+++ b/POSClient/ViewModels/BalanceDetailViewModel.swift
@@ -8,7 +8,7 @@
 
 import OmiseGO
 
-class BalanceDetailViewModel: BaseViewModel {
+class BalanceDetailViewModel: BaseViewModel, BalanceDetailViewModelProtocol {
     var onFailGetWallet: FailureClosure?
     var onDataUpdate: SuccessClosure?
     var onLoadStateChange: ObjectClosure<Bool>?

--- a/POSClient/ViewModels/BalanceListViewModel.swift
+++ b/POSClient/ViewModels/BalanceListViewModel.swift
@@ -8,7 +8,7 @@
 
 import OmiseGO
 
-class BalanceListViewModel: BaseViewModel {
+class BalanceListViewModel: BaseViewModel, BalanceListViewModelProtocol {
     // Delegate Closures
     var onFailGetWallet: FailureClosure?
     var onTableDataChange: SuccessClosure?
@@ -42,7 +42,7 @@ class BalanceListViewModel: BaseViewModel {
         self.onBalanceSelection?(balance)
     }
 
-    func process(wallet: Wallet?) {
+    private func process(wallet: Wallet?) {
         guard let wallet = wallet else { return }
         self.generateTableViewModels(fromBalances: wallet.balances)
         self.onTableDataChange?()

--- a/POSClient/ViewModels/BalanceNavigationViewModel.swift
+++ b/POSClient/ViewModels/BalanceNavigationViewModel.swift
@@ -8,12 +8,12 @@
 
 import OmiseGO
 
-class BalanceNavigationViewModel: BaseViewModel {
-    enum DisplayStyle {
-        case single
-        case list
-    }
+enum DisplayStyle {
+    case single
+    case list
+}
 
+class BalanceNavigationViewModel: BaseViewModel, BalanceNavigationViewModelProtocol {
     private let sessionManager: SessionManagerProtocol
 
     var onDisplayStyleUpdate: EmptyClosure?

--- a/POSClient/ViewModels/LoadingViewModel.swift
+++ b/POSClient/ViewModels/LoadingViewModel.swift
@@ -8,7 +8,7 @@
 
 import OmiseGO
 
-class LoadingViewModel: BaseViewModel {
+class LoadingViewModel: BaseViewModel, LoadingViewModelProtocol {
     var onFailedLoading: FailureClosure?
     var onLoadStateChange: ObjectClosure<Bool>?
 

--- a/POSClient/ViewModels/LoginViewModel.swift
+++ b/POSClient/ViewModels/LoginViewModel.swift
@@ -7,7 +7,7 @@
 //
 import OmiseGO
 
-class LoginViewModel: BaseViewModel {
+class LoginViewModel: BaseViewModel, LoginViewModelProtocol {
     // Delegate closures
     var updateEmailValidation: ViewModelValidationClosure?
     var updatePasswordValidation: ViewModelValidationClosure?

--- a/POSClient/ViewModels/ProfileTableViewModel.swift
+++ b/POSClient/ViewModels/ProfileTableViewModel.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ProfileTableViewModel: BaseViewModel {
+class ProfileTableViewModel: BaseViewModel, ProfileTableViewModelProtocol {
     let title = "profile.view.title".localized()
     let transactionLabelText = "profile.label.transactions".localized()
     let emailLabelText = "profile.label.email".localized()

--- a/POSClient/ViewModels/QRViewModel.swift
+++ b/POSClient/ViewModels/QRViewModel.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class QRViewModel: BaseViewModel {
+class QRViewModel: BaseViewModel, QRViewModelProtocol {
     private let sessionManager: SessionManagerProtocol
     let title: String = "qr_viewer.label.your_qr".localized()
     let hint: String = "qr_viewer.label.hint".localized()

--- a/POSClient/ViewModels/SignupViewModel.swift
+++ b/POSClient/ViewModels/SignupViewModel.swift
@@ -8,7 +8,7 @@
 
 import OmiseGO
 
-class SignupViewModel: BaseViewModel {
+class SignupViewModel: BaseViewModel, SignupViewModelProtocol {
     // Delegate closures
     var updateEmailValidation: ViewModelValidationClosure?
     var updatePasswordValidation: ViewModelValidationClosure?

--- a/POSClient/ViewModels/TouchIDConfirmationViewModel.swift
+++ b/POSClient/ViewModels/TouchIDConfirmationViewModel.swift
@@ -8,7 +8,7 @@
 
 import OmiseGO
 
-class TouchIDConfirmationViewModel: BaseViewModel {
+class TouchIDConfirmationViewModel: BaseViewModel, TouchIDConfirmationViewModelProtocol {
     // Delegate closures
     var updatePasswordValidation: ViewModelValidationClosure?
     var onSuccessEnable: EmptyClosure?

--- a/POSClient/ViewModels/TransactionsViewModel.swift
+++ b/POSClient/ViewModels/TransactionsViewModel.swift
@@ -9,7 +9,7 @@
 import OmiseGO
 import UIKit
 
-class TransactionsViewModel: BaseViewModel {
+class TransactionsViewModel: BaseViewModel, TransactionsViewModelProtocol {
     // Delegate closures
     var appendNewResultClosure: ObjectClosure<[IndexPath]>?
     var reloadTableViewClosure: EmptyClosure?

--- a/POSClientTests/TestMocks/TestBalanceDetailViewModel.swift
+++ b/POSClientTests/TestMocks/TestBalanceDetailViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  TestBalanceDetailViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+@testable import POSClient
+
+class TestBalanceDetailViewModel: BalanceDetailViewModelProtocol {
+    var onFailGetWallet: FailureClosure?
+    var onDataUpdate: SuccessClosure?
+    var onLoadStateChange: ObjectClosure<Bool>?
+
+    var balanceDisplay: String = "x"
+    var tokenSymbol: String = "x"
+    var title: String = "x"
+    var lastUpdatedString: String = "x"
+    var lastUpdated: String = "x"
+    var payOrTopupAttrStr: NSAttributedString = NSAttributedString(string: "x")
+    var balance: Balance? = StubGenerator.mainWallet().balances.first
+
+    func loadData() {
+        self.isLoadDataCalled = true
+    }
+
+    func stopObserving() {
+        self.isStopObservingCalled = true
+    }
+
+    var isLoadDataCalled = false
+    var isStopObservingCalled = false
+}

--- a/POSClientTests/TestMocks/TestBalanceListViewModel.swift
+++ b/POSClientTests/TestMocks/TestBalanceListViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  TestBalanceListViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import OmiseGO
+@testable import POSClient
+
+class TestBalanceListViewModel: BalanceListViewModelProtocol {
+    var onFailGetWallet: FailureClosure?
+    var onTableDataChange: SuccessClosure?
+    var onBalanceSelection: ObjectClosure<Balance>?
+
+    var viewTitle: String = "x"
+
+    func loadData() {
+        self.isLoadDataCalled = true
+    }
+
+    func numberOfRow() -> Int {
+        self.isNumberOfRowCalled = true
+        return self.rowCount
+    }
+
+    func cellViewModel(forIndex _: Int) -> BalanceCellViewModel {
+        self.isCellViewModelCalled = true
+        return self.cellVM
+    }
+
+    func didSelectBalance(atIndex index: Int) {
+        self.selectedBalanceIndex = index
+    }
+
+    var isLoadDataCalled = false
+    var rowCount: Int = 0
+    var isNumberOfRowCalled = false
+    var cellVM: BalanceCellViewModel = BalanceCellViewModel(balance: StubGenerator.mainWalletSingleBalance().balances.first!)
+    var isCellViewModelCalled = false
+    var selectedBalanceIndex: Int?
+}

--- a/POSClientTests/TestMocks/TestBalanceNavigationViewModel.swift
+++ b/POSClientTests/TestMocks/TestBalanceNavigationViewModel.swift
@@ -1,0 +1,25 @@
+//
+//  TestBalanceNavigationViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import POSClient
+
+class TestBalanceNavigationViewModel: BalanceNavigationViewModelProtocol {
+    var onDisplayStyleUpdate: EmptyClosure?
+    var displayStyle: DisplayStyle = .list
+
+    func stopObserving() {
+        self.isStopObservingCalled = true
+    }
+
+    func updateBalances() {
+        self.isUpdateBalancesCalled = true
+    }
+
+    var isStopObservingCalled = false
+    var isUpdateBalancesCalled = false
+}

--- a/POSClientTests/TestMocks/TestLoadingViewModel.swift
+++ b/POSClientTests/TestMocks/TestLoadingViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  TestLoadingViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import POSClient
+
+class TestLoadingViewModel: LoadingViewModelProtocol {
+    var onFailedLoading: FailureClosure?
+    var onLoadStateChange: ObjectClosure<Bool>?
+
+    var isLoading: Bool = true
+
+    var retryButtonTitle: String = "x"
+
+    func load() {
+        self.isLoadCalled = true
+    }
+
+    var isLoadCalled: Bool = false
+}

--- a/POSClientTests/TestMocks/TestLoginViewModel.swift
+++ b/POSClientTests/TestMocks/TestLoginViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  TestLoginViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 11/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import POSClient
+import UIKit
+
+class TestLoginViewModel: LoginViewModelProtocol {
+    var updateEmailValidation: ViewModelValidationClosure?
+    var updatePasswordValidation: ViewModelValidationClosure?
+    var onFailedLogin: FailureClosure?
+    var onLoadStateChange: ObjectClosure<Bool>?
+
+    var emailPlaceholder: String = "x"
+    var passwordPlaceholder: String = "x"
+    var loginButtonTitle: String = "x"
+    var registerButtonTitle: String = "x"
+    var isBiometricAvailable: Bool = false
+    var touchFaceIdButtonTitle: String = "x"
+    var touchFaceIdButtonPicture: UIImage?
+
+    var email: String?
+    var password: String?
+
+    func bioLogin() {
+        self.isBioLoginCalled = true
+    }
+
+    func login() {
+        self.isLoginCalled = true
+    }
+
+    var isBioLoginCalled: Bool = false
+    var isLoginCalled: Bool = false
+}

--- a/POSClientTests/TestMocks/TestProfileTableViewModel.swift
+++ b/POSClientTests/TestMocks/TestProfileTableViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  TestProfileTableViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import POSClient
+
+class TestProfileTableViewModel: ProfileTableViewModelProtocol {
+    var title: String = "x"
+    var transactionLabelText: String = "x"
+    var emailLabelText: String = "x"
+    var signOutLabelText: String = "x"
+
+    var onFailLogout: FailureClosure?
+    var onLoadStateChange: ObjectClosure<Bool>?
+    var shouldShowEnableConfirmationView: EmptyClosure?
+    var onBioStateChange: ObjectClosure<Bool>?
+
+    var switchState: Bool = false
+    var isBiometricAvailable: Bool = false
+    var touchFaceIdLabelText: String = "x"
+    var emailValueLabelText: String = "x"
+
+    func toggleSwitch(newValue isEnabled: Bool) {
+        self.isToggleSwitchWithValue = isEnabled
+    }
+
+    func logout() {
+        self.isLogoutCalled = true
+    }
+
+    func stopObserving() {
+        self.isStopObservingCalled = true
+    }
+
+    var isToggleSwitchWithValue: Bool?
+    var isLogoutCalled = false
+    var isStopObservingCalled = false
+}

--- a/POSClientTests/TestMocks/TestQRViewModel.swift
+++ b/POSClientTests/TestMocks/TestQRViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  TestQRViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import POSClient
+import UIKit
+
+class TestQRViewModel: QRViewModelProtocol {
+    var title: String = "x"
+    var hint: String = "x"
+
+    func qrImage(withWidth width: CGFloat) -> UIImage? {
+        self.didCallQRImageWithWidth = width
+        return nil
+    }
+
+    var didCallQRImageWithWidth: CGFloat?
+}

--- a/POSClientTests/TestMocks/TestSignupViewModel.swift
+++ b/POSClientTests/TestMocks/TestSignupViewModel.swift
@@ -1,0 +1,37 @@
+//
+//  TestSignupViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import POSClient
+
+class TestSignupViewModel: SignupViewModelProtocol {
+    var updateEmailValidation: ViewModelValidationClosure?
+    var updatePasswordValidation: ViewModelValidationClosure?
+    var updatePasswordConfirmationValidation: ViewModelValidationClosure?
+    var updatePasswordMatchingValidation: ViewModelValidationClosure?
+    var onSuccessfulSignup: EmptyClosure?
+    var onFailedSignup: FailureClosure?
+    var onLoadStateChange: ObjectClosure<Bool>?
+
+    var title: String = "x"
+    var emailPlaceholder: String = "x"
+    var passwordPlaceholder: String = "x"
+    var passwordConfirmationPlaceholder: String = "x"
+    var passwordHint: String = "x"
+    var terms: String = "x"
+    var signupButtonTitle: String = "x"
+
+    var email: String?
+    var password: String?
+    var passwordConfirmation: String?
+
+    func signup() {
+        self.isSignupCalled = true
+    }
+
+    var isSignupCalled = false
+}

--- a/POSClientTests/TestMocks/TestTouchIDConfirmationViewModel.swift
+++ b/POSClientTests/TestMocks/TestTouchIDConfirmationViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  TestTouchIDConfirmationViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+@testable import POSClient
+
+class TestTouchIDConfirmationViewModel: TouchIDConfirmationViewModelProtocol {
+    var updatePasswordValidation: ViewModelValidationClosure?
+    var onSuccessEnable: EmptyClosure?
+    var onFailedEnable: FailureClosure?
+    var onLoadStateChange: ObjectClosure<Bool>?
+
+    var title: String = "x"
+    var passwordPlaceholder: String = "x"
+    var emailString: String = "x"
+    var enableButtonTitle: String = "x"
+    var hintString: String = "x"
+
+    var password: String?
+
+    func enable() {
+        self.isEnableCalled = true
+    }
+
+    var isEnableCalled = false
+}

--- a/POSClientTests/TestMocks/TestTransactionsViewModel.swift
+++ b/POSClientTests/TestMocks/TestTransactionsViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  TestTransactionsViewModel.swift
+//  POSClientTests
+//
+//  Created by Mederic Petit on 12/9/18.
+//  Copyright © 2018 Omise Go Pte. Ltd. All rights reserved.
+//
+
+import UIKit
+@testable import POSClient
+
+class TestTransactionsViewModel: TransactionsViewModelProtocol {
+    var appendNewResultClosure: ObjectClosure<[IndexPath]>?
+    var reloadTableViewClosure: EmptyClosure?
+    var onFailLoadTransactions: FailureClosure?
+    var onLoadStateChange: ObjectClosure<Bool>?
+
+    var viewTitle: String = "x"
+
+    func reloadTransactions() {
+        self.isReloadTransactionCalled = true
+    }
+
+    func getNextTransactions() {
+        self.isGetNextTransactionsCalled = true
+    }
+
+    func transactionCellViewModel(at indexPath: IndexPath) -> TransactionCellViewModel {
+        self.isTransactionCellViewModelCalledWithIndexPath = indexPath
+        return self.cellVM
+    }
+
+    func numberOfRow() -> Int {
+        self.isNumberOfRowCalled = true
+        return self.rowCount
+    }
+
+    func shouldLoadNext(atIndexPath indexPath: IndexPath) -> Bool {
+        self.isShouldLoadNextCalledWithIndexPath = indexPath
+        return false
+    }
+
+    var rowCount: Int = 0
+    var cellVM = TransactionCellViewModel(transaction: StubGenerator.transactions().first!, currentUserAddress: "x")
+    var isReloadTransactionCalled = false
+    var isGetNextTransactionsCalled = false
+    var isTransactionCellViewModelCalledWithIndexPath: IndexPath?
+    var isNumberOfRowCalled = false
+    var isShouldLoadNextCalledWithIndexPath: IndexPath?
+}

--- a/POSClientTests/ViewControllers/BalanceDetailViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BalanceDetailViewControllerTests.swift
@@ -25,6 +25,7 @@ class BalanceDetailViewControllerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         ToastCenter.default.cancelAll()
+        self.viewModel = nil
         self.sut = nil
     }
 

--- a/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
@@ -12,10 +12,12 @@ import XCTest
 
 class BalanceListViewControllerTests: XCTestCase {
     var sut: BalanceListViewController!
+    var viewModel: TestBalanceListViewModel!
 
     override func setUp() {
         super.setUp()
-        self.sut = Storyboard.balance.storyboard.instantiateViewController(withIdentifier: "BalanceListViewController") as! BalanceListViewController
+        self.viewModel = TestBalanceListViewModel()
+        self.sut = BalanceListViewController.initWithViewModel(self.viewModel)
         _ = UINavigationController(rootViewController: self.sut)
         _ = self.sut.view
     }
@@ -29,12 +31,13 @@ class BalanceListViewControllerTests: XCTestCase {
     func testSetupsCorrectly() {
         XCTAssertEqual(self.sut.tableView.estimatedRowHeight, 72)
         XCTAssertEqual(self.sut.tableView.refreshControl, self.sut.refreshControl)
+        XCTAssertEqual(self.sut.navigationItem.title, "x")
     }
 
     func testOnTableDataChangeEndRefresh() {
         self.sut.refreshControl.beginRefreshing()
         XCTAssertTrue(self.sut.refreshControl.isRefreshing)
-        self.sut.viewModel.onTableDataChange?()
+        self.viewModel.onTableDataChange?()
         XCTAssertFalse(self.sut.refreshControl.isRefreshing)
     }
 
@@ -42,7 +45,7 @@ class BalanceListViewControllerTests: XCTestCase {
         self.sut.refreshControl.beginRefreshing()
         XCTAssertTrue(self.sut.refreshControl.isRefreshing)
         let error = POSClientError.unexpected
-        self.sut.viewModel.onFailGetWallet?(error)
+        self.viewModel.onFailGetWallet?(error)
         XCTAssertEqual(ToastCenter.default.currentToast!.text, error.message)
         XCTAssertFalse(self.sut.refreshControl.isRefreshing)
     }
@@ -52,7 +55,7 @@ class BalanceListViewControllerTests: XCTestCase {
         XCTAssertEqual(self.sut.navigationController!.viewControllers.count, 1)
         let balance = StubGenerator.mainWallet().balances.first!
         dispatchMain {
-            self.sut.viewModel.onBalanceSelection?(balance)
+            self.viewModel.onBalanceSelection?(balance)
             e.fulfill()
         }
         self.waitForExpectations(timeout: 1, handler: nil)
@@ -63,5 +66,25 @@ class BalanceListViewControllerTests: XCTestCase {
             return
         }
         XCTAssertEqual(balanceDetailViewController.viewModel.balance!, balance)
+    }
+
+    func testRefreshControllerTriggersLoadData() {
+        self.sut.refreshControl.sendActions(for: .valueChanged)
+        XCTAssertTrue(self.viewModel.isLoadDataCalled)
+    }
+
+    func testNumberOfRowInSection() {
+        self.viewModel.rowCount = 10
+        XCTAssertEqual(self.sut.tableView(self.sut.tableView, numberOfRowsInSection: 0), 10)
+    }
+
+    func testCellForRow() {
+        let cell = self.sut.tableView(self.sut.tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as! BalanceTableViewCell
+        XCTAssertEqual(cell.balanceTableViewModel, self.viewModel.cellVM)
+    }
+
+    func testDidSelectRowCallsDidSelectBalance() {
+        self.sut.tableView(self.sut.tableView, didSelectRowAt: IndexPath(row: 5, section: 0))
+        XCTAssertEqual(self.viewModel.selectedBalanceIndex!, 5)
     }
 }

--- a/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
@@ -25,6 +25,7 @@ class BalanceListViewControllerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         ToastCenter.default.cancelAll()
+        self.viewModel = nil
         self.sut = nil
     }
 

--- a/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
@@ -60,12 +60,7 @@ class BalanceListViewControllerTests: XCTestCase {
         }
         self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertEqual(self.sut.navigationController!.viewControllers.count, 2)
-        guard let balanceDetailViewController: BalanceDetailViewController =
-            self.sut.navigationController!.viewControllers[1] as? BalanceDetailViewController else {
-            XCTFail("Unexpected view contrller type")
-            return
-        }
-        XCTAssertEqual(balanceDetailViewController.viewModel.balance!, balance)
+        XCTAssertTrue(self.sut.navigationController!.viewControllers[1].isKind(of: BalanceDetailViewController.self))
     }
 
     func testRefreshControllerTriggersLoadData() {

--- a/POSClientTests/ViewControllers/BalanceNavigationViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BalanceNavigationViewControllerTests.swift
@@ -11,26 +11,36 @@ import XCTest
 
 class BalanceNavigationViewControllerTests: XCTestCase {
     var sut: BalanceNavigationViewController!
+    var viewModel: TestBalanceNavigationViewModel!
 
     override func setUp() {
         super.setUp()
-        self.sut = Storyboard.balance.storyboard.instantiateViewController(withIdentifier: "BalanceNavigationViewController")
-            as! BalanceNavigationViewController
+        self.viewModel = TestBalanceNavigationViewModel()
+        self.sut = BalanceNavigationViewController.initWithViewModel(self.viewModel)
         _ = self.sut.view
     }
 
     override func tearDown() {
         super.tearDown()
         self.sut = nil
+        self.viewModel = nil
     }
 
     func testSingleBalanceDisplaysBalanceDetailVC() {
-        self.sut.viewModel.displayStyle = .single
+        self.viewModel.displayStyle = .single
+        self.viewModel.onDisplayStyleUpdate?()
         XCTAssertTrue(self.sut.viewControllers[0].isKind(of: BalanceDetailViewController.self))
     }
 
     func testListBalanceDisplaysBalanceListVC() {
-        self.sut.viewModel.displayStyle = .list
+        self.viewModel.displayStyle = .list
+        self.viewModel.onDisplayStyleUpdate?()
         XCTAssertTrue(self.sut.viewControllers[0].isKind(of: BalanceListViewController.self))
+    }
+
+    func testViewWillAppearCallsUpdateBalances() {
+        self.viewModel.isUpdateBalancesCalled = false
+        self.sut.viewWillAppear(false)
+        XCTAssertTrue(self.viewModel.isUpdateBalancesCalled)
     }
 }

--- a/POSClientTests/ViewControllers/LoadingViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/LoadingViewControllerTests.swift
@@ -12,36 +12,44 @@ import XCTest
 
 class LoadingViewControllerTests: XCTestCase {
     var sut: LoadingViewController!
+    var viewModel: TestLoadingViewModel!
 
     override func setUp() {
         super.setUp()
-        self.sut = Storyboard.loading.storyboard.instantiateViewController(withIdentifier: "LoadingViewController") as! LoadingViewController
+        self.viewModel = TestLoadingViewModel()
+        self.sut = LoadingViewController.initWithViewModel(self.viewModel)
         _ = self.sut.view
     }
 
     override func tearDown() {
         super.tearDown()
         ToastCenter.default.cancelAll()
+        self.viewModel = nil
         self.sut = nil
     }
 
     func testSetupsCorrectly() {
-        XCTAssertEqual(self.sut.retryButton.titleLabel?.text, self.sut.viewModel.retryButtonTitle)
+        XCTAssertEqual(self.sut.retryButton.titleLabel?.text, "x")
         XCTAssertTrue(self.sut.retryButton.isHidden)
     }
 
     func testFailedLoadinShowsError() {
         let error = POSClientError.unexpected
-        self.sut.viewModel.onFailedLoading?(error)
+        self.viewModel.onFailedLoading?(error)
         XCTAssertEqual(ToastCenter.default.currentToast!.text, error.message)
     }
 
     func testLoadStateChangeTriggersLoadingAndRetryButtonVisibiliyChange() {
-        self.sut.viewModel.onLoadStateChange?(true)
+        self.viewModel.onLoadStateChange?(true)
         XCTAssertTrue(self.sut.loadingImageView.isAnimating)
         XCTAssertTrue(self.sut.retryButton.isHidden)
-        self.sut.viewModel.onLoadStateChange?(false)
+        self.viewModel.onLoadStateChange?(false)
         XCTAssertFalse(self.sut.loadingImageView.isAnimating)
         XCTAssertFalse(self.sut.retryButton.isHidden)
+    }
+
+    func testTapRetryButtonTriggersLoad() {
+        self.sut.tapRetryButton(self.sut.retryButton)
+        XCTAssertTrue(self.viewModel.isLoadCalled)
     }
 }

--- a/POSClientTests/ViewControllers/LoginViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/LoginViewControllerTests.swift
@@ -12,10 +12,12 @@ import XCTest
 
 class LoginViewControllerTests: XCTestCase {
     var sut: LoginViewController!
+    var viewModel: TestLoginViewModel!
 
     override func setUp() {
         super.setUp()
-        self.sut = Storyboard.login.storyboard.instantiateViewController(withIdentifier: "LoginViewController") as! LoginViewController
+        self.viewModel = TestLoginViewModel()
+        self.sut = LoginViewController.initWithViewModel(self.viewModel)
         _ = self.sut.view
     }
 
@@ -32,28 +34,37 @@ class LoginViewControllerTests: XCTestCase {
     }
 
     func testSetupsCorrectly() {
-        XCTAssertEqual(self.sut.emailTextField.placeholder, self.sut.viewModel.emailPlaceholder)
-        XCTAssertEqual(self.sut.passwordTextField.placeholder, self.sut.viewModel.passwordPlaceholder)
-        XCTAssertEqual(self.sut.loginButton.titleLabel?.text, self.sut.viewModel.loginButtonTitle)
-        XCTAssertEqual(self.sut.registerButton.titleLabel?.text, self.sut.viewModel.registerButtonTitle)
+        XCTAssertEqual(self.sut.emailTextField.placeholder, "x")
+        XCTAssertEqual(self.sut.passwordTextField.placeholder, "x")
+        XCTAssertEqual(self.sut.loginButton.titleLabel?.text, "x")
+        XCTAssertEqual(self.sut.registerButton.titleLabel?.text, "x")
         XCTAssertTrue(self.sut.bioLoginButton.isHidden)
     }
 
+    func testBioLoginButtonSetupsCorrectly() {
+        let viewModel = TestLoginViewModel()
+        viewModel.isBiometricAvailable = true
+        let sut = LoginViewController.initWithViewModel(viewModel)!
+        _ = sut.view
+        XCTAssertFalse(sut.bioLoginButton.isHidden)
+        XCTAssertEqual(sut.bioLoginButton.titleLabel?.text, "x")
+    }
+
     func testInvalidEmailShowsError() {
-        self.sut.viewModel.updateEmailValidation?("qwe")
+        self.viewModel.updateEmailValidation?("qwe")
         XCTAssertEqual(self.sut.emailTextField.errorMessage, "qwe")
     }
 
     func testInvalidPasswordShowsError() {
-        self.sut.viewModel.updatePasswordValidation?("123")
+        self.viewModel.updatePasswordValidation?("123")
         XCTAssertEqual(self.sut.passwordTextField.errorMessage, "123")
     }
 
     func testLoadStateChangeTriggersLoading() {
         let e = self.expectation(description: "loading state change triggers loading view to show/hide")
-        self.sut.viewModel.onLoadStateChange?(true)
+        self.viewModel.onLoadStateChange?(true)
         XCTAssertEqual(self.sut.loading!.alpha, 1.0)
-        self.sut.viewModel.onLoadStateChange?(false)
+        self.viewModel.onLoadStateChange?(false)
         dispatchMain(afterMilliseconds: 10) {
             e.fulfill()
         }
@@ -63,20 +74,20 @@ class LoginViewControllerTests: XCTestCase {
 
     func testFailedLoginShowsError() {
         let error = POSClientError.unexpected
-        self.sut.viewModel.onFailedLogin?(error)
+        self.viewModel.onFailedLogin?(error)
         XCTAssertEqual(ToastCenter.default.currentToast!.text, error.message)
     }
 
     func testEmailTextFieldChangeUpdatesViewModelEmailAttribute() {
         let range = NSRange(location: 0, length: 0)
         _ = self.sut.textField(self.sut.emailTextField, shouldChangeCharactersIn: range, replacementString: "123")
-        XCTAssertEqual(self.sut.viewModel.email, "123")
+        XCTAssertEqual(self.viewModel.email, "123")
     }
 
     func testPasswordTextFieldChangeUpdatesViewModelPasswordAttribute() {
         let range = NSRange(location: 0, length: 0)
         _ = self.sut.textField(self.sut.passwordTextField, shouldChangeCharactersIn: range, replacementString: "123")
-        XCTAssertEqual(self.sut.viewModel.password, "123")
+        XCTAssertEqual(self.viewModel.password, "123")
     }
 
     func testReturningEmailTFFocusPasswordTF() {
@@ -99,18 +110,42 @@ class LoginViewControllerTests: XCTestCase {
         dispatchMain { e.fulfill() }
         self.waitForExpectations(timeout: 1, handler: nil)
         XCTAssertFalse(self.sut.passwordTextField.isFirstResponder)
-        XCTAssertEqual(ToastCenter.default.currentToast!.text, "Missing required fields")
+        XCTAssertTrue(self.viewModel.isLoginCalled)
     }
 
     func testClearEmailTFClearsViewModelEmail() {
-        self.sut.viewModel.email = "123"
+        self.viewModel.email = "123"
         _ = self.sut.textFieldShouldClear(self.sut.emailTextField)
-        XCTAssertEqual(self.sut.viewModel.email, "")
+        XCTAssertEqual(self.viewModel.email, "")
     }
 
     func testClearPWTFClearsViewModelPW() {
-        self.sut.viewModel.password = "123"
+        self.viewModel.password = "123"
         _ = self.sut.textFieldShouldClear(self.sut.passwordTextField)
-        XCTAssertEqual(self.sut.viewModel.password, "")
+        XCTAssertEqual(self.viewModel.password, "")
+    }
+
+    func testTapLoginButtonTriggersLoginAndResignFirstResponder() {
+        self.mountOnWindow()
+        self.sut.emailTextField.becomeFirstResponder()
+        XCTAssertTrue(self.sut.emailTextField.isFirstResponder)
+        self.sut.tapLoginButton(self.sut.loginButton)
+        let e = self.expectation(description: "Tap on log in button resigns first responder and trigger log in")
+        dispatchMain { e.fulfill() }
+        self.waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertFalse(self.sut.emailTextField.isFirstResponder)
+        XCTAssertTrue(self.viewModel.isLoginCalled)
+    }
+
+    func testTapBioLoginButtonTriggersBioLoginAndResignFirstResponder() {
+        self.mountOnWindow()
+        self.sut.emailTextField.becomeFirstResponder()
+        XCTAssertTrue(self.sut.emailTextField.isFirstResponder)
+        self.sut.tapBioLoginButton(self.sut.bioLoginButton)
+        let e = self.expectation(description: "Tap on bio log in button resigns first responder and trigger bio log in")
+        dispatchMain { e.fulfill() }
+        self.waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertFalse(self.sut.emailTextField.isFirstResponder)
+        XCTAssertTrue(self.viewModel.isBioLoginCalled)
     }
 }

--- a/POSClientTests/ViewControllers/LoginViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/LoginViewControllerTests.swift
@@ -24,6 +24,7 @@ class LoginViewControllerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         ToastCenter.default.cancelAll()
+        self.viewModel = nil
         self.sut = nil
     }
 

--- a/POSClientTests/ViewControllers/QRViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/QRViewControllerTests.swift
@@ -11,23 +11,25 @@ import XCTest
 
 class QRViewControllerTests: XCTestCase {
     var sut: QRViewController!
+    var viewModel: TestQRViewModel!
 
     override func setUp() {
         super.setUp()
-        self.sut = Storyboard.qrCode.storyboard.instantiateViewController(withIdentifier: "QRViewController")
-            as! QRViewController
-        SessionManager.shared.wallet = StubGenerator.mainWallet()
+        self.viewModel = TestQRViewModel()
+        self.sut = QRViewController.initWithViewModel(self.viewModel)
         _ = self.sut.view
     }
 
     override func tearDown() {
         super.tearDown()
         self.sut = nil
+        self.viewModel = nil
     }
 
     func testSetupsCorrectly() {
-        XCTAssertEqual(self.sut.hintLabel.text, self.sut.viewModel.hint)
-        XCTAssertEqual(self.sut.navigationItem.title, self.sut.viewModel.title)
-        XCTAssertNotNil(self.sut.qrImageView.image)
+        XCTAssertEqual(self.sut.hintLabel.text, "x")
+        XCTAssertEqual(self.sut.navigationItem.title, "x")
+        XCTAssertNil(self.sut.qrImageView.image)
+        XCTAssertEqual(self.viewModel.didCallQRImageWithWidth, CGFloat(self.sut.qrImageView.frame.width))
     }
 }

--- a/POSClientTests/ViewControllers/TransactionsViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/TransactionsViewControllerTests.swift
@@ -12,10 +12,12 @@ import XCTest
 
 class TransactionsViewControllerTests: XCTestCase {
     var sut: TransactionsViewController!
+    var viewModel: TestTransactionsViewModel!
 
     override func setUp() {
         super.setUp()
-        self.sut = Storyboard.transaction.storyboard.instantiateViewController(withIdentifier: "TransactionsViewController") as! TransactionsViewController
+        self.viewModel = TestTransactionsViewModel()
+        self.sut = TransactionsViewController.initWithViewModel(self.viewModel)
         _ = UINavigationController(rootViewController: self.sut)
         _ = self.sut.view
     }
@@ -27,16 +29,17 @@ class TransactionsViewControllerTests: XCTestCase {
     }
 
     func testSetupsCorrectly() {
-        XCTAssertEqual(self.sut.title, self.sut.viewModel.viewTitle)
+        XCTAssertEqual(self.sut.title, "x")
         XCTAssertEqual(self.sut.tableView.estimatedRowHeight, 62)
         XCTAssertEqual(self.sut.tableView.rowHeight, 62)
         XCTAssertEqual(self.sut.tableView.refreshControl, self.sut.refreshControl)
+        self.viewModel.isReloadTransactionCalled = true
     }
 
     func testReloadTableViewClosureEndRefres() {
         self.sut.refreshControl!.beginRefreshing()
         XCTAssertTrue(self.sut.refreshControl!.isRefreshing)
-        self.sut.viewModel.reloadTableViewClosure?()
+        self.viewModel.reloadTableViewClosure?()
         XCTAssertFalse(self.sut.refreshControl!.isRefreshing)
     }
 
@@ -44,12 +47,37 @@ class TransactionsViewControllerTests: XCTestCase {
         self.sut.refreshControl!.beginRefreshing()
         XCTAssertTrue(self.sut.refreshControl!.isRefreshing)
         let error = POSClientError.unexpected
-        self.sut.viewModel.onFailLoadTransactions?(error)
+        self.viewModel.onFailLoadTransactions?(error)
         XCTAssertEqual(ToastCenter.default.currentToast!.text, error.message)
         XCTAssertFalse(self.sut.refreshControl!.isRefreshing)
     }
 
     func testAppendNewResultClosureInsertsDataInTable() {
-        // TODO: update after refactor
+        self.viewModel.rowCount = 1
+        let indexPath = IndexPath(row: 0, section: 0)
+        self.viewModel.appendNewResultClosure?([indexPath])
+        let cell = self.sut.tableView(self.sut.tableView, cellForRowAt: indexPath)
+        XCTAssertNotNil(cell)
+    }
+
+    func testRefreshControllerTriggersReloadTransactions() {
+        self.sut.refreshControl!.sendActions(for: .valueChanged)
+        XCTAssertTrue(self.viewModel.isReloadTransactionCalled)
+    }
+
+    func testNumberOfRowInSection() {
+        self.viewModel.rowCount = 10
+        XCTAssertEqual(self.sut.tableView(self.sut.tableView, numberOfRowsInSection: 0), 10)
+    }
+
+    func testCellForRow() {
+        let cell = self.sut.tableView(self.sut.tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as! TransactionTableViewCell
+        XCTAssertEqual(cell.transactionCellViewModel, self.viewModel.cellVM)
+    }
+
+    func testWillDisplayCellTriggersLoadNextCorrectly() {
+        let indexPath = IndexPath(row: 0, section: 0)
+        self.sut.tableView(self.sut.tableView, willDisplay: TransactionTableViewCell(style: .default, reuseIdentifier: nil), forRowAt: indexPath)
+        XCTAssertEqual(self.viewModel.isShouldLoadNextCalledWithIndexPath!, indexPath)
     }
 }

--- a/POSClientTests/ViewModelTests/BalanceListViewModelTests.swift
+++ b/POSClientTests/ViewModelTests/BalanceListViewModelTests.swift
@@ -71,13 +71,6 @@ class BalanceListViewModelTests: XCTestCase {
         XCTAssertEqual(cellViewModel.tokenSymbol, "BTC")
     }
 
-    func testProcessGeneratesViewModelsCorrectly() {
-        let wallet = StubGenerator.mainWallet()
-        self.sut.process(wallet: wallet)
-        XCTAssertEqual(wallet.balances.count, self.sut.numberOfRow())
-        XCTAssertEqual(wallet.balances.first!, self.sut.cellViewModel(forIndex: 0).balance)
-    }
-
     func testDidSelectBalanceCallsOnBalanceSelection() {
         var selectedBalance: Balance?
         self.sut.onBalanceSelection = { balance in


### PR DESCRIPTION
Closes #29 

# Overview

This PR refactors view controllers in order to make them easily testable.
The view model referenced in the controller is now a protocol interface so we can mock its data when testing.