### PR TITLE
Update with latest OmiseGO SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: swift
 osx_image: xcode10
-before_install:
-  pod repo update
-script:
-  set -o pipefail &&
-  xcodebuild -workspace POSClient.xcworkspace -scheme "POSClient" -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone X" test | xcpretty ;
+cache: cocoapods
+xcode_workspace: POSClient.xcworkspace
+xcode_scheme: POSClient
+xcode_destination: platform=iOS Simulator,name=iPhone X

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ cache: cocoapods
 xcode_workspace: POSClient.xcworkspace
 xcode_scheme: POSClient
 xcode_destination: platform=iOS Simulator,name=iPhone X
+before_install:
+  pod repo update

--- a/POSClient.xcodeproj/project.pbxproj
+++ b/POSClient.xcodeproj/project.pbxproj
@@ -812,12 +812,12 @@
 				"${BUILT_PRODUCTS_DIR}/MarqueeLabel/MarqueeLabel.framework",
 				"${BUILT_PRODUCTS_DIR}/NotificationBannerSwift/NotificationBannerSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/OmiseGO/OmiseGO.framework",
+				"${BUILT_PRODUCTS_DIR}/SBToaster/SBToaster.framework",
 				"${BUILT_PRODUCTS_DIR}/SipHash/SipHash.framework",
 				"${BUILT_PRODUCTS_DIR}/SkyFloatingLabelTextField/SkyFloatingLabelTextField.framework",
 				"${BUILT_PRODUCTS_DIR}/SnapKit/SnapKit.framework",
 				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
 				"${BUILT_PRODUCTS_DIR}/TPKeyboardAvoiding/TPKeyboardAvoiding.framework",
-				"${BUILT_PRODUCTS_DIR}/Toaster/Toaster.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
@@ -828,12 +828,12 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MarqueeLabel.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NotificationBannerSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OmiseGO.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SBToaster.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SipHash.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SkyFloatingLabelTextField.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SnapKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TPKeyboardAvoiding.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toaster.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/POSClient/Helpers/BaseViewControllerProtocols.swift
+++ b/POSClient/Helpers/BaseViewControllerProtocols.swift
@@ -7,7 +7,7 @@
 //
 
 import MBProgressHUD
-import Toaster
+import SBToaster
 
 protocol Configurable {
     func configureView()

--- a/POSClientTests/TestMocks/TestLoginViewModel.swift
+++ b/POSClientTests/TestMocks/TestLoginViewModel.swift
@@ -10,7 +10,6 @@
 import UIKit
 
 class TestLoginViewModel: LoginViewModelProtocol {
-
     var updateEmailValidation: ViewModelValidationClosure?
     var updatePasswordValidation: ViewModelValidationClosure?
     var onFailedLogin: FailureClosure?

--- a/POSClientTests/ViewControllers/BalanceDetailViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BalanceDetailViewControllerTests.swift
@@ -8,7 +8,7 @@
 
 import OmiseGO
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class BalanceDetailViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BalanceListViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class BalanceListViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/BaseViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/BaseViewControllerTests.swift
@@ -8,7 +8,7 @@
 
 import MBProgressHUD
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class BaseViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/ConsumptionConfirmationViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/ConsumptionConfirmationViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class ConsumptionConfirmationViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/LoadingViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/LoadingViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class LoadingViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/LoginViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/LoginViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class LoginViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/ProfileTableViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/ProfileTableViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class ProfileTableViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/QRViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/QRViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class QRViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/SignupViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/SignupViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class SignupViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/TouchIDConfirmationViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/TouchIDConfirmationViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class TouchIDConfirmationViewControllerTests: XCTestCase {

--- a/POSClientTests/ViewControllers/TransactionsViewControllerTests.swift
+++ b/POSClientTests/ViewControllers/TransactionsViewControllerTests.swift
@@ -7,7 +7,7 @@
 //
 
 @testable import POSClient
-import Toaster
+import SBToaster
 import XCTest
 
 class TransactionsViewControllerTests: XCTestCase {

--- a/Podfile
+++ b/Podfile
@@ -10,25 +10,15 @@ target 'POSClient' do
   pod 'KeychainAccess'
   pod 'BigInt'
   pod 'MBProgressHUD'
-  pod 'Toaster'
+  pod 'SBToaster'
   pod 'TPKeyboardAvoiding'
   pod 'SkyFloatingLabelTextField'
   pod 'NotificationBannerSwift'
-  pod 'OmiseGO/Client', '1.1.0-beta2'
+  pod 'OmiseGO/Client', '~> 1.1.0'
 
   target 'POSClientTests' do
     inherit! :search_paths
     # Pods for testing
   end
 
-end
-
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        if target.name == 'Toaster'
-            target.build_configurations.each do |config|
-                config.build_settings['SWIFT_VERSION'] = '4.0'
-            end
-        end
-    end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,23 +1,23 @@
 PODS:
-  - Alamofire (4.7.3)
+  - Alamofire (4.8.1)
   - BigInt (3.1.0):
     - SipHash (~> 1.2)
   - KeychainAccess (3.1.2)
   - MarqueeLabel/Swift (3.2.0)
   - MBProgressHUD (1.1.0)
-  - NotificationBannerSwift (1.7.3):
+  - NotificationBannerSwift (2.0.1):
     - MarqueeLabel/Swift (~> 3.2.0)
-    - SnapKit (~> 4.0.1)
-  - OmiseGO/Client (1.1.0-beta2):
+    - SnapKit (~> 4.2.0)
+  - OmiseGO/Client (1.1.0):
     - OmiseGO/Core
-  - OmiseGO/Core (1.1.0-beta2):
+  - OmiseGO/Core (1.1.0):
     - BigInt (~> 3.1)
     - Starscream (~> 3.0)
+  - SBToaster (2.1.2)
   - SipHash (1.2.2)
   - SkyFloatingLabelTextField (3.6.0)
-  - SnapKit (4.0.1)
+  - SnapKit (4.2.0)
   - Starscream (3.0.6)
-  - Toaster (2.1.1)
   - TPKeyboardAvoiding (1.3.2)
 
 DEPENDENCIES:
@@ -26,9 +26,9 @@ DEPENDENCIES:
   - KeychainAccess
   - MBProgressHUD
   - NotificationBannerSwift
-  - OmiseGO/Client (= 1.1.0-beta2)
+  - OmiseGO/Client (~> 1.1.0)
+  - SBToaster
   - SkyFloatingLabelTextField
-  - Toaster
   - TPKeyboardAvoiding
 
 SPEC REPOS:
@@ -40,28 +40,28 @@ SPEC REPOS:
     - MBProgressHUD
     - NotificationBannerSwift
     - OmiseGO
+    - SBToaster
     - SipHash
     - SkyFloatingLabelTextField
     - SnapKit
     - Starscream
-    - Toaster
     - TPKeyboardAvoiding
 
 SPEC CHECKSUMS:
-  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
+  Alamofire: 16ce2c353fb72865124ddae8a57c5942388f4f11
   BigInt: 76b5dfdfa3e2e478d4ffdf161aeede5502e2742f
   KeychainAccess: b3816fddcf28aa29d94b10ec305cd52be14c472b
   MarqueeLabel: 440a502b91a9179bd98f9fff00ba1150650a1c0e
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  NotificationBannerSwift: c9f4bc868d78df975ed59c0b2fccdbbe0e863efe
-  OmiseGO: 1548d22049d99e650cba3dd3843d9ebf2af53d36
+  NotificationBannerSwift: 007774aa590cc9680647b92b2f217bef5c00c32c
+  OmiseGO: 377bd1a344cc4e7bd5bba0e56e2b760a326837ef
+  SBToaster: ffea00ad8c38eb80e6800c0fee5bc9b4c184252b
   SipHash: fad90a4683e420c52ef28063063dbbce248ea6d4
   SkyFloatingLabelTextField: 38164979b79512f9ff9288ad8acfc4bbf5d843e3
-  SnapKit: 0de968a9fec17499afa29683b05d0c775b6d1c29
+  SnapKit: fe8a619752f3f27075cc9a90244d75c6c3f27e2a
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
-  Toaster: a6c9532de1ded8105e77376f7dffeb2e12b46dbb
   TPKeyboardAvoiding: cb69d5ddbe90ce0170e4bc2db1e5e41d4a3ad9a4
 
-PODFILE CHECKSUM: 656d7c8541d2fb892627eb0c960a9ad1332a7767
+PODFILE CHECKSUM: be2c5bc6097b3be2f365b31a388efd192660816e
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Closes #43 

# Overview

This PR mainly bumps the OmiseGO SDK version to `1.1.0` and updates the corresponding code.

# Changes

- Update Podfile to use the version `1.1.0` of the OmiseGO SDK
- Update Podfile and related files to use the forked `SBToaster` instead of `Toaster` which is not yet compatible with swift 4.2.
